### PR TITLE
Don't mutate the given character string

### DIFF
--- a/lib/anybase.rb
+++ b/lib/anybase.rb
@@ -8,7 +8,7 @@ class Anybase
   attr_reader :chars, :char_map, :num_map, :regexp
 
   def initialize(chars, opts = nil)
-    @chars = chars
+    @chars = chars.dup
     @ignore_case = opts && opts.key?(:ignore_case) ? opts[:ignore_case] : false
     @sign = opts && opts.key?(:sign) ? opts[:sign] : nil
     raise if @sign && @chars.index(@sign)


### PR DESCRIPTION
When given the option to ignore case, the gem called `downcase!` on the values which mutated the string from the calling code. This prevents that by just duplicating the character string we're passed.